### PR TITLE
remove beep menu item that summary page added

### DIFF
--- a/client/src/main/scala/com/example/pages/duplicate/PageSummary.scala
+++ b/client/src/main/scala/com/example/pages/duplicate/PageSummary.scala
@@ -694,7 +694,7 @@ object PageSummaryInternal {
                       "Select For Print"
                   )
                 )
-                BeepComponent.getMenuItem( ()=>scope.withEffectsImpure.forceUpdate)::x
+                x
               }
             ):_*
           }


### PR DESCRIPTION
The DuplicatePageBridgeAppBar adds beep menu item to all pages.

#214: Add some games to demo mode

closes #212 