### PR TITLE
Release

### DIFF
--- a/client/src/main/scala/com/example/pages/Pixels.scala
+++ b/client/src/main/scala/com/example/pages/Pixels.scala
@@ -17,6 +17,12 @@ object Pixels {
     window.getComputedStyle(elem)
   }
 
+  def getElementAndComputedProperties( id: String ) = {
+    val elem = Bridge.getElement(id)
+    val window = document.defaultView
+    (elem,window.getComputedStyle(elem))
+  }
+
   /**
    * Returns the computed font for the element with the specified Id.
    * @param id
@@ -55,6 +61,13 @@ object Pixels {
     val ml = getPixels( "borderLeft", computed.borderLeft, id )
     val mr = getPixels( "borderRight", computed.borderRight, id )
     pl+pr+ml+mr
+  }
+
+  def getWidthWithBoarder( id: String ) = {
+    val (elem,computed) = getElementAndComputedProperties(id)
+    val ml = getPixels( "borderLeft", computed.borderLeft, id )
+    val mr = getPixels( "borderRight", computed.borderRight, id )
+    elem.clientWidth+ml+mr
   }
 
   /**

--- a/client/src/main/scala/com/example/pages/chicagos/PageChicagoList.scala
+++ b/client/src/main/scala/com/example/pages/chicagos/PageChicagoList.scala
@@ -184,9 +184,10 @@ object PageChicagoListInternal {
                         <.th( "Created", <.br(), "Updated"),
                         <.th( "Players - Scores", ^.colSpan:=maxplayers),
                         <.th( "")
-                    )),
+                      ),
+                      ChicagoRowFirst.withKey("New")((this,props,state,maxplayers,importId)),
+                    ),
                     <.tbody(
-                        ChicagoRowFirst.withKey("New")((this,props,state,maxplayers,importId)),
                         (0 until chicagos.length).map { i =>
                           val key="Game"+i
                           val chicago = ChicagoScoring(chicagos(i))
@@ -271,7 +272,7 @@ object PageChicagoListInternal {
     .render_P { args =>
       val (backend, props, state, maxplayers, importId) = args
       <.tr(
-          <.td( "" ),
+          <.th( "" ),
           importId.map { id =>
             TagMod(
               <.th(id),
@@ -279,12 +280,12 @@ object PageChicagoListInternal {
               <.th( "" )
             )
           }.getOrElse(
-            <.td(
+            <.th(
               AppButton( "New", "New", ^.onClick --> backend.newChicago)
             )
           ),
-          <.td( ^.colSpan:=maxplayers,"" ),
-          <.td( "")
+          <.th( ^.colSpan:=maxplayers,"" ),
+          <.th( "")
           )
     }.build
 

--- a/client/src/main/scala/com/example/pages/duplicate/DuplicateStyles.scala
+++ b/client/src/main/scala/com/example/pages/duplicate/DuplicateStyles.scala
@@ -52,6 +52,8 @@ class DuplicateStyles {
 
   val divScoreboardPage = cls("dupDivScoreboardPage")
   val divViewScoreboard = cls("dupDivViewScoreboard")
+  val divViewScoreboardAllButtons = cls("dupDivViewScoreboardAllButtons")
+
   val tableViewScoreboard = cls("dupTableViewScoreboard")
   val cellScoreboardBoardColumn = cls("dupCellScoreboardBoardColumn")
 

--- a/client/src/main/scala/com/example/pages/duplicate/PageTableTeams.scala
+++ b/client/src/main/scala/com/example/pages/duplicate/PageTableTeams.scala
@@ -38,7 +38,7 @@ import com.example.data.bridge._
 import scala.scalajs.js.JSConverters._
 import com.example.react.Button
 import com.example.pages.hand.PageHand
-import com.example.pages.hand.Properties
+import com.example.pages.hand.{ Properties => HProperties}
 import com.example.pages.Pixels
 import com.example.pages.BaseStyles
 import com.example.react.HelpButton
@@ -707,8 +707,8 @@ object PageTableTeamsInternal {
     }
 
     def renderSelectScorekeeper( props: Props, state: State ): (TagMod, Option[String]) = {
-      val extraWidth = Properties.defaultHandButtonBorderRadius+
-                       Properties.defaultHandButtonPaddingBorder
+      val extraWidth = HProperties.defaultHandButtonBorderRadius+
+                       HProperties.defaultHandButtonPaddingBorder
       val width = s"${Pixels.maxLength( state.players.players(): _* )+extraWidth}px"
       val bwidth: TagMod = ^.width := width
       ( <.div(

--- a/client/src/main/scala/com/example/pages/duplicate/Properties.scala
+++ b/client/src/main/scala/com/example/pages/duplicate/Properties.scala
@@ -1,0 +1,47 @@
+package com.example.pages.duplicate
+
+import com.example.pages.Pixels
+import com.example.Bridge
+
+object Properties {
+
+  val viewportContent = {
+    val elem = Bridge.getElement("metaViewport")
+    elem.getAttribute("content")
+  }
+
+  val defaultScoreboardWidth = Pixels.getWidthWithBoarder("DefaultScoreboard")
+  val defaultNumberOfBoards = 18
+  val defaultScoreboardBoardWidth = Pixels.getWidthWithBoarder("DefaultScoreboardBoard")
+  val defaultScoreboardPlayersWidth = Pixels.getWidthWithBoarder("DefaultScoreboardPlayers")
+  val defaultScoreboardNamesWidthWithoutName = Pixels.getPaddingBorder("DefaultScoreboardNames")
+  val defaultScoreboardTitleBoards = Pixels.getWidthWithBoarder("DefaultScoreboardTitleBoards")
+
+  def getScoreboardWidth( boards: Int, names: String* ) = {
+    val nameLen = Pixels.maxLength(names:_*)+defaultScoreboardNamesWidthWithoutName
+    val playerlen = Math.max(defaultScoreboardPlayersWidth, nameLen)
+
+    defaultScoreboardWidth-
+        defaultScoreboardTitleBoards-
+        defaultScoreboardPlayersWidth+
+        playerlen+
+        boards*defaultScoreboardBoardWidth
+  }
+
+  def setViewportContent( boards: Int, names: String* ) = {
+    val w = getScoreboardWidth(boards, names:_*)
+    setViewportContentWidth(w)
+  }
+
+  def setViewportContentWidth( pixels: Int ) = {
+    val nc = viewportContent.replace("width=device-width", s"width=${pixels}px")
+    val elem = Bridge.getElement("metaViewport")
+    elem.setAttribute("content",nc)
+  }
+
+  def restoreViewportContentWidth() = {
+    val elem = Bridge.getElement("metaViewport")
+    elem.setAttribute("content",viewportContent)
+  }
+
+}

--- a/client/src/main/scala/com/example/pages/duplicate/ViewScoreboard.scala
+++ b/client/src/main/scala/com/example/pages/duplicate/ViewScoreboard.scala
@@ -190,6 +190,11 @@ object ViewScoreboardInternal {
    */
   class Backend(scope: BackendScope[Props, State]) {
     def render( props: Props, state: State ) = {
+      {
+        val names = props.score.teams.flatMap( t => t.player1::t.player2::Nil)
+        val boards = props.score.boards.size
+        Properties.setViewportContent(boards, names:_*)
+      }
       def teamColumn( teams: List[Team] ) = {
         var count = 0
         for (team <- teams.sortWith((t1,t2)=> Id.idComparer(t1.id, t2.id)<0)) yield {
@@ -256,12 +261,18 @@ object ViewScoreboardInternal {
       )
     }
 
+    val willUnmount = CallbackTo {
+      logger.info("ViewScoreboard.willUnmount")
+      Properties.restoreViewportContentWidth()
+    }
+
   }
 
   val component = ScalaComponent.builder[Props]("ViewScoreboard")
                             .initialStateFromProps { props => State() }
                             .backend(new Backend(_))
                             .renderBackend
+                            .componentWillUnmount( scope => scope.backend.willUnmount )
                             .build
 }
 

--- a/client/src/main/scala/com/example/pages/duplicate/ViewScoreboard.scala
+++ b/client/src/main/scala/com/example/pages/duplicate/ViewScoreboard.scala
@@ -200,6 +200,11 @@ object ViewScoreboardInternal {
       val showidbutton = props.page.isInstanceOf[FinishedScoreboardView]
       <.div(
         dupStyles.divViewScoreboard,
+        props.page.getPerspective() match {
+          case PerspectiveDirector => dupStyles.divViewScoreboardAllButtons
+          case PerspectiveComplete => dupStyles.divViewScoreboardAllButtons
+          case PerspectiveTable(t1, t2) => TagMod()
+        },
         <.table( ^.id := "scoreboard",
           dupStyles.tableViewScoreboard,
           <.caption(

--- a/server/src/main/public/css/duplicate.css
+++ b/server/src/main/public/css/duplicate.css
@@ -244,12 +244,14 @@
   page-break-inside: avoid !important;
 }
 
+/*
 @media screen and (max-width: 1025px) {
   .dupDivViewScoreboardAllButtons {
     transform: scale(.93);
     transform-origin: top left;
   }
 }
+*/
 
 .dupTableViewScoreboard {
   border-spacing: 0px;

--- a/server/src/main/public/css/duplicate.css
+++ b/server/src/main/public/css/duplicate.css
@@ -241,7 +241,14 @@
   margin-right: 5px;
   padding-right: 5px;
   padding-bottom: 5px;
-  page-break-inside: avoid !important
+  page-break-inside: avoid !important;
+}
+
+@media screen and (max-width: 1025px) {
+  .dupDivViewScoreboardAllButtons {
+    transform: scale(.93);
+    transform-origin: top left;
+  }
 }
 
 .dupTableViewScoreboard {

--- a/server/src/main/public/defaults.html
+++ b/server/src/main/public/defaults.html
@@ -1,19 +1,188 @@
 <!DOCTYPE html>
 <html>
 <body>
-	<div>
-		<div class="handPageHand ">
-			<button type="button" id="DefaultHandButton"
-				class="baseRequiredNotNext">
-				<span id="East">East Player<span> (2)</span> <span
-					id="DefaultHandVul" class="handNotVulnerable"
-					style="padding: 1px 5px;">vul</span> <span> East</span></span>
-			</button>
-		</div>
-		<div class="chiViewPlayersSecondRound">
-			<button type="button" id="DefaultChicagoNameButton"
-				class="baseNameButton baseButtonSelected baseAppButton baseDefaultButton baseFontTextLarge">Sam</button>
-		</div>
-	</div>
+ <div>
+  <div class="handPageHand ">
+   <button type="button" id="DefaultHandButton"
+    class="baseRequiredNotNext">
+    <span id="East">East Player<span> (2)</span> <span
+     id="DefaultHandVul" class="handNotVulnerable"
+     style="padding: 1px 5px;">vul</span> <span> East</span></span>
+   </button>
+  </div>
+  <div class="chiViewPlayersSecondRound">
+   <button type="button" id="DefaultChicagoNameButton"
+    class="baseNameButton baseButtonSelected baseAppButton baseDefaultButton baseFontTextLarge">Sam</button>
+  </div>
+
+  <div class="dupDivViewScoreboard dupDivViewScoreboardAllButtons">
+   <table id="DefaultScoreboard" class="dupTableViewScoreboard">
+    <caption>
+     Scoreboard with completed boards only, Mar 9, 2019<span
+      style="float: right;"><span>M62</span></span><span
+      style="float: left;"><span>M62</span></span>
+    </caption>
+    <thead>
+     <tr>
+      <th rowspan="2">Team</th>
+      <th rowspan="2"  id="DefaultScoreboardPlayers">Players</th>
+      <th rowspan="2">Total</th>
+      <th colspan="18" id="DefaultScoreboardTitleBoards">Boards</th>
+     </tr>
+     <tr>
+      <th class="dupCellScoreboardBoardColumn"><button
+        type="button" id="Board_B1"
+        class="baseAppButton baseDefaultButton baseFontTextLarge">1</button></th>
+      <th class="dupCellScoreboardBoardColumn"><button
+        type="button" id="Board_B1"
+        class="baseAppButton baseDefaultButton baseFontTextLarge">2</button></th>
+      <th class="dupCellScoreboardBoardColumn"><button
+        type="button" id="Board_B1"
+        class="baseAppButton baseDefaultButton baseFontTextLarge">3</button></th>
+      <th class="dupCellScoreboardBoardColumn"><button
+        type="button" id="Board_B1"
+        class="baseAppButton baseDefaultButton baseFontTextLarge">4</button></th>
+      <th class="dupCellScoreboardBoardColumn"><button
+        type="button" id="Board_B1"
+        class="baseAppButton baseDefaultButton baseFontTextLarge">5</button></th>
+      <th class="dupCellScoreboardBoardColumn"><button
+        type="button" id="Board_B1"
+        class="baseAppButton baseDefaultButton baseFontTextLarge">6</button></th>
+      <th class="dupCellScoreboardBoardColumn"><button
+        type="button" id="Board_B1"
+        class="baseAppButton baseDefaultButton baseFontTextLarge">7</button></th>
+      <th class="dupCellScoreboardBoardColumn"><button
+        type="button" id="Board_B1"
+        class="baseAppButton baseDefaultButton baseFontTextLarge">8</button></th>
+      <th class="dupCellScoreboardBoardColumn"><button
+        type="button" id="Board_B1"
+        class="baseAppButton baseDefaultButton baseFontTextLarge">9</button></th>
+      <th class="dupCellScoreboardBoardColumn"><button
+        type="button" id="Board_B1"
+        class="baseAppButton baseDefaultButton baseFontTextLarge">10</button></th>
+      <th class="dupCellScoreboardBoardColumn"><button
+        type="button" id="Board_B1"
+        class="baseAppButton baseDefaultButton baseFontTextLarge">11</button></th>
+      <th class="dupCellScoreboardBoardColumn"><button
+        type="button" id="Board_B1"
+        class="baseAppButton baseDefaultButton baseFontTextLarge">12</button></th>
+      <th class="dupCellScoreboardBoardColumn"><button
+        type="button" id="Board_B1"
+        class="baseAppButton baseDefaultButton baseFontTextLarge">13</button></th>
+      <th class="dupCellScoreboardBoardColumn"><button
+        type="button" id="Board_B1"
+        class="baseAppButton baseDefaultButton baseFontTextLarge">14</button></th>
+      <th class="dupCellScoreboardBoardColumn"><button
+        type="button" id="Board_B1"
+        class="baseAppButton baseDefaultButton baseFontTextLarge">15</button></th>
+      <th class="dupCellScoreboardBoardColumn"><button
+        type="button" id="Board_B1"
+        class="baseAppButton baseDefaultButton baseFontTextLarge">16</button></th>
+      <th class="dupCellScoreboardBoardColumn"><button
+        type="button" id="Board_B1"
+        class="baseAppButton baseDefaultButton baseFontTextLarge">17</button></th>
+      <th class="dupCellScoreboardBoardColumn" id="DefaultScoreboardBoard"><button
+        type="button" id="Board_B1"
+        class="baseAppButton baseDefaultButton baseFontTextLarge">18</button></th>
+     </tr>
+    </thead>
+    <tbody>
+     <tr>
+      <td>1</td>
+      <td id="DefaultScoreboardNames"><br></td>
+      <td>0</td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+     </tr>
+     <tr>
+      <td>2</td>
+      <td><br></td>
+      <td>0</td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+     </tr>
+     <tr>
+      <td>3</td>
+      <td><br></td>
+      <td>0</td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+     </tr>
+     <tr>
+      <td>4</td>
+      <td><br></td>
+      <td>0</td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+      <td><span></span></td>
+     </tr>
+    </tbody>
+   </table>
+  </div>
+
+ </div>
 </body>
 </html>

--- a/server/src/main/public/defaults.html
+++ b/server/src/main/public/defaults.html
@@ -31,58 +31,58 @@
      </tr>
      <tr>
       <th class="dupCellScoreboardBoardColumn"><button
-        type="button" id="Board_B1"
+        type="button" id="xx_B1"
         class="baseAppButton baseDefaultButton baseFontTextLarge">1</button></th>
       <th class="dupCellScoreboardBoardColumn"><button
-        type="button" id="Board_B1"
+        type="button" id="xx_B1"
         class="baseAppButton baseDefaultButton baseFontTextLarge">2</button></th>
       <th class="dupCellScoreboardBoardColumn"><button
-        type="button" id="Board_B1"
+        type="button" id="xx_B1"
         class="baseAppButton baseDefaultButton baseFontTextLarge">3</button></th>
       <th class="dupCellScoreboardBoardColumn"><button
-        type="button" id="Board_B1"
+        type="button" id="xx_B1"
         class="baseAppButton baseDefaultButton baseFontTextLarge">4</button></th>
       <th class="dupCellScoreboardBoardColumn"><button
-        type="button" id="Board_B1"
+        type="button" id="xx_B1"
         class="baseAppButton baseDefaultButton baseFontTextLarge">5</button></th>
       <th class="dupCellScoreboardBoardColumn"><button
-        type="button" id="Board_B1"
+        type="button" id="xx_B1"
         class="baseAppButton baseDefaultButton baseFontTextLarge">6</button></th>
       <th class="dupCellScoreboardBoardColumn"><button
-        type="button" id="Board_B1"
+        type="button" id="xx_B1"
         class="baseAppButton baseDefaultButton baseFontTextLarge">7</button></th>
       <th class="dupCellScoreboardBoardColumn"><button
-        type="button" id="Board_B1"
+        type="button" id="xx_B1"
         class="baseAppButton baseDefaultButton baseFontTextLarge">8</button></th>
       <th class="dupCellScoreboardBoardColumn"><button
-        type="button" id="Board_B1"
+        type="button" id="xx_B1"
         class="baseAppButton baseDefaultButton baseFontTextLarge">9</button></th>
       <th class="dupCellScoreboardBoardColumn"><button
-        type="button" id="Board_B1"
+        type="button" id="xx_B1"
         class="baseAppButton baseDefaultButton baseFontTextLarge">10</button></th>
       <th class="dupCellScoreboardBoardColumn"><button
-        type="button" id="Board_B1"
+        type="button" id="xx_B1"
         class="baseAppButton baseDefaultButton baseFontTextLarge">11</button></th>
       <th class="dupCellScoreboardBoardColumn"><button
-        type="button" id="Board_B1"
+        type="button" id="xx_B1"
         class="baseAppButton baseDefaultButton baseFontTextLarge">12</button></th>
       <th class="dupCellScoreboardBoardColumn"><button
-        type="button" id="Board_B1"
+        type="button" id="xx_B1"
         class="baseAppButton baseDefaultButton baseFontTextLarge">13</button></th>
       <th class="dupCellScoreboardBoardColumn"><button
-        type="button" id="Board_B1"
+        type="button" id="xx_B1"
         class="baseAppButton baseDefaultButton baseFontTextLarge">14</button></th>
       <th class="dupCellScoreboardBoardColumn"><button
-        type="button" id="Board_B1"
+        type="button" id="xx_B1"
         class="baseAppButton baseDefaultButton baseFontTextLarge">15</button></th>
       <th class="dupCellScoreboardBoardColumn"><button
-        type="button" id="Board_B1"
+        type="button" id="xx_B1"
         class="baseAppButton baseDefaultButton baseFontTextLarge">16</button></th>
       <th class="dupCellScoreboardBoardColumn"><button
-        type="button" id="Board_B1"
+        type="button" id="xx_B1"
         class="baseAppButton baseDefaultButton baseFontTextLarge">17</button></th>
       <th class="dupCellScoreboardBoardColumn" id="DefaultScoreboardBoard"><button
-        type="button" id="Board_B1"
+        type="button" id="xx_B1"
         class="baseAppButton baseDefaultButton baseFontTextLarge">18</button></th>
      </tr>
     </thead>

--- a/server/src/main/public/index-fastopt.html
+++ b/server/src/main/public/index-fastopt.html
@@ -15,7 +15,7 @@
     <style id="allowSelect">
     </style>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width">
+    <meta id="metaViewport" name="viewport" content="width=device-width">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="format-detection" content="telephone=no">
     <meta name="format-detection" content="date=no">

--- a/server/src/main/public/index-jsconsole.html
+++ b/server/src/main/public/index-jsconsole.html
@@ -15,7 +15,7 @@
     <style id="allowSelect">
     </style>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width">
+    <meta id="metaViewport" name="viewport" content="width=device-width">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="format-detection" content="telephone=no">
     <meta name="format-detection" content="date=no">

--- a/server/src/main/public/index.html
+++ b/server/src/main/public/index.html
@@ -17,7 +17,7 @@
     <style id="allowSelect">
     </style>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width">
+    <meta id="metaViewport" name="viewport" content="width=device-width">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="format-detection" content="telephone=no">
     <meta name="format-detection" content="date=no">

--- a/server/src/main/public/indexNoScale.html
+++ b/server/src/main/public/indexNoScale.html
@@ -22,7 +22,7 @@
     <meta name="format-detection" content="date=no">
     <meta name="format-detection" content="address=no">
     <meta name="format-detection" content="email=no">
-    <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1">
+    <meta id="metaViewport" name="viewport" content="width=device-width, user-scalable=no, initial-scale=1">
     <title>The Bridge Score Keeper</title>
     <style>
       @media screen and (orientation: landscape) {

--- a/server/src/test/scala/com/example/test/pages/Pages.scala
+++ b/server/src/test/scala/com/example/test/pages/Pages.scala
@@ -137,11 +137,17 @@ abstract class Page[ +T <: Page[T] ]()( implicit webDriver: WebDriver, pageCreat
   def findButtons( map: Map[String,String] )(implicit pos: Position): Map[String,Element] = {
     val buttons = findButtons( map.keySet.toList :_* )
 
-    buttons.foreach{ case (id,e) => map.get(id) match {
-      case Some(t) => e.text mustBe t
-      case None =>
-    }}
-    buttons
+    withClue(s"""finding buttons ${map}""") {
+      buttons.foreach{ case (id,e) => map.get(id) match {
+        case Some(t) =>
+          withClue(s"""checking text on $id to be $t""") {
+            val txt = e.text
+            txt mustBe t
+          }
+        case None =>
+      }}
+      buttons
+    }
   }
 
   /**

--- a/server/src/test/scala/com/example/test/pages/bridge/HomePage.scala
+++ b/server/src/test/scala/com/example/test/pages/bridge/HomePage.scala
@@ -30,6 +30,7 @@ object HomePage {
 
   def urlFor = TestServer.getAppPage()
 
+  val divBridgeAppPrefix = """//div[@id="BridgeApp"]"""
 }
 
 class HomePage( implicit webDriver: WebDriver, pageCreated: SourcePosition ) extends Page[HomePage] {

--- a/server/src/test/scala/com/example/test/pages/bridge/ImportPage.scala
+++ b/server/src/test/scala/com/example/test/pages/bridge/ImportPage.scala
@@ -71,14 +71,14 @@ class ImportPage( implicit val webDriver: WebDriver, pageCreated: SourcePosition
   }
 
   def isWorking(implicit pos: Position) = {
-    findElemByXPath("//table/tbody/tr[1]/td[1]").text == "Working"
+    findElemByXPath(HomePage.divBridgeAppPrefix+"//table/tbody/tr[1]/td[1]").text == "Working"
   }
 
   /**
    * @return list of tuple2.  Each tuple2 is (importId,row)
    */
   def getImportedIds(implicit patienceConfig: PatienceConfig, pos: Position) = eventually {
-    val r = findElemsByXPath("//table/tbody/tr/td[1]").map( e => e.text ).zipWithIndex
+    val r = findElemsByXPath(HomePage.divBridgeAppPrefix+"//table/tbody/tr/td[1]").map( e => e.text ).zipWithIndex
     if (r.length == 1) {
       r.head._1 must not be "Working"
     }

--- a/server/src/test/scala/com/example/test/pages/chicago/ListPage.scala
+++ b/server/src/test/scala/com/example/test/pages/chicago/ListPage.scala
@@ -78,11 +78,11 @@ class ListPage( importId: Option[String] = None )( implicit val webDriver: WebDr
   }
 
   def getMatchButtons()(implicit pos: Position) = {
-    getElemsByXPath("""//div/table/tbody/tr/td[1]/button""").map(e => e.text)
+    getElemsByXPath(HomePage.divBridgeAppPrefix+"""//div[contains(concat(' ', @class, ' '), ' chiChicagoListPage ')]//div/table/tbody/tr/td[1]/button""").map(e => e.text)
   }
 
   def getImportButtons()(implicit pos: Position) = {
-    getElemsByXPath("""//div/table/tbody/tr/td[2]/button""").flatMap(e => e.id.toList)
+    getElemsByXPath(HomePage.divBridgeAppPrefix+"""//div/table/tbody/tr/td[2]/button""").flatMap(e => e.id.toList)
   }
 
   def checkMatchButton( id: String )(implicit pos: Position) = {

--- a/server/src/test/scala/com/example/test/pages/duplicate/BoardPage.scala
+++ b/server/src/test/scala/com/example/test/pages/duplicate/BoardPage.scala
@@ -25,6 +25,7 @@ import com.example.data.bridge.Vulnerability
 import com.example.data.bridge.Vul
 import com.example.data.bridge.NotVul
 import com.example.test.pages.Element
+import com.example.test.pages.bridge.HomePage
 
 object BoardPage {
 
@@ -274,7 +275,7 @@ class BoardPage( implicit webDriver: WebDriver, pageCreated: SourcePosition ) ex
   }
 
   private def getTeamRow( team: Int )(implicit pos: Position) = {
-    findElemsByXPath(s"""//table/tbody/tr[${team}]/td""")
+    findElemsByXPath(HomePage.divBridgeAppPrefix+s"""//table/tbody/tr[${team}]/td""")
   }
 
   def checkTeamNSScore( team: Int,

--- a/server/src/test/scala/com/example/test/pages/duplicate/BoardsPage.scala
+++ b/server/src/test/scala/com/example/test/pages/duplicate/BoardsPage.scala
@@ -25,6 +25,7 @@ import com.example.data.bridge.Vulnerability
 import com.example.data.bridge.Vul
 import com.example.data.bridge.NotVul
 import com.example.test.pages.PageBrowser
+import com.example.test.pages.bridge.HomePage
 
 object BoardsPage {
 
@@ -360,7 +361,7 @@ class BoardsPage( implicit webDriver: WebDriver, pageCreated: SourcePosition ) e
   }
 
   def getBoardIds(implicit patienceConfig: PatienceConfig, pos: Position) = eventually {
-    findElemsByXPath("""//table""").flatMap(e => elemIdToBoardId(e.attribute("id").get) match {
+    findElemsByXPath(HomePage.divBridgeAppPrefix+"""//table""").flatMap(e => elemIdToBoardId(e.attribute("id").get) match {
       case Some(id) => id::Nil
       case None => Nil
     } ).sorted

--- a/server/src/test/scala/com/example/test/pages/duplicate/ListDuplicatePage.scala
+++ b/server/src/test/scala/com/example/test/pages/duplicate/ListDuplicatePage.scala
@@ -133,7 +133,7 @@ class ListDuplicatePage( importId: Option[String] )( implicit val webDriver: Web
 
   def isWorking(implicit patienceConfig: PatienceConfig, pos: Position): Boolean = {
     try {
-      val text = find(xpath("""//div/table/tbody/tr[1]/td[1]""")).text
+      val text = find(xpath(HomePage.divBridgeAppPrefix+"""//div/table/tbody/tr[1]/td[1]""")).text
       val rc = text == "Working"
       log.fine( s"""Looking for working on duplicate list page, rc=${rc}: "${text}"""" )
       rc
@@ -146,7 +146,7 @@ class ListDuplicatePage( importId: Option[String] )( implicit val webDriver: Web
   def isForPrintActive( implicit pos: Position ) = {
     // importId.isEmpty && findAll(id("ForPrint")).isEmpty
     if (importId.isEmpty) {
-      val els = getElemsByXPath(s"""//div/table/thead/tr[1]/th[2]""")
+      val els = getElemsByXPath(HomePage.divBridgeAppPrefix+s"""//div/table/thead/tr[1]/th[2]""")
       if (els.size == 1) {
         els.head.text.equals("Print")
       } else {
@@ -233,7 +233,7 @@ class ListDuplicatePage( importId: Option[String] )( implicit val webDriver: Web
     // 3 = Id, Created, Finished
     // Note the scoring method header does not show up in this row.
     val dr = 4+importColumns+(if (forPrintActive) 1 else 0)
-    val names = getElemsByXPath("""//div/table/thead/tr/th""").drop(dr)
+    val names = getElemsByXPath(HomePage.divBridgeAppPrefix+"""//div/table/thead/tr/th""").drop(dr)
     names.dropRight(1).map(e => e.text)
   }
 
@@ -242,7 +242,7 @@ class ListDuplicatePage( importId: Option[String] )( implicit val webDriver: Web
     withClueAndScreenShot(screenshotDir, "getResults", s"""working on results from match ${id}, ${pos.line}""") {
       eventually {
         val forPrintActive = isForPrintActive
-        val row = getElemsByXPath(s"""//div/table/tbody/tr[td/button[@id='${matchIdToButtonId(id)}' or @id='${resultIdToButtonId(id)}']]/td""")
+        val row = getElemsByXPath(HomePage.divBridgeAppPrefix+s"""//div/table/tbody/tr[td/button[@id='${matchIdToButtonId(id)}' or @id='${resultIdToButtonId(id)}']]/td""")
         val names = getNames(forPrintActive)
         // 4 = Id, Created, Finished, scoring method
         val dr = 4+importColumns+(if (forPrintActive) 1 else 0)

--- a/server/src/test/scala/com/example/test/pages/duplicate/ScoreboardPage.scala
+++ b/server/src/test/scala/com/example/test/pages/duplicate/ScoreboardPage.scala
@@ -210,17 +210,21 @@ class ScoreboardPage(
     sb
   }}
 
-  def validate(boards: List[Int])(implicit patienceConfig: PatienceConfig, pos: Position) = logMethod(s"${pos.line} ${getClass.getSimpleName}.validate") { eventually {
-    val did = validateInternal
+  def validate(boards: List[Int])(implicit patienceConfig: PatienceConfig, pos: Position) = logMethod(s"${pos.line} ${getClass.getSimpleName}.validate") {
+    eventually {
+      logMethod(s"${pos.line} ${getClass.getSimpleName}.validate inside eventually") {
+        val did = validateInternal
 
-    val ids = buttonIds(view) :::
-              (for (i <- boards) yield {
-                ("Board_B"+i, i.toString() )
-              }).toList
+        val ids = buttonIds(view) :::
+                  (for (i <- boards) yield {
+                    ("Board_B"+i, i.toString() )
+                  }).toList
 
-    val buttons = findButtons( Map( ids:_* ) )
-    new ScoreboardPage( Option(did) )
-  }}
+        val buttons = findButtons( Map( ids:_* ) )
+        new ScoreboardPage( Option(did) )
+      }
+    }
+  }
 
   def clickMainMenu(implicit patienceConfig: PatienceConfig, pos: Position) = {
     clickButton("MainMenu")

--- a/server/src/test/scala/com/example/test/pages/duplicate/StatisticsPage.scala
+++ b/server/src/test/scala/com/example/test/pages/duplicate/StatisticsPage.scala
@@ -98,7 +98,7 @@ class StatisticsPage( implicit webDriver: WebDriver, pageCreated: SourcePosition
 
   def isWorking(implicit patienceConfig: PatienceConfig, pos: Position): Boolean = {
     try {
-      val text = find(xpath("""//div/table/tbody/tr[1]/td[2]""")).text
+      val text = find(xpath(HomePage.divBridgeAppPrefix+"""//div/table/tbody/tr[1]/td[2]""")).text
       val rc = text == "Working"
       log.fine( s"""Looking for working on people page, rc=${rc}: "${text}"""" )
       rc

--- a/server/src/test/scala/com/example/test/pages/duplicate/TableSelectNamesPage.scala
+++ b/server/src/test/scala/com/example/test/pages/duplicate/TableSelectNamesPage.scala
@@ -23,6 +23,7 @@ import com.example.data.bridge.South
 import com.example.data.bridge.East
 import com.example.data.bridge.West
 import com.example.data.util.Strings
+import com.example.test.pages.bridge.HomePage
 
 object TableSelectNamesPage {
 
@@ -171,7 +172,7 @@ class TableSelectNamesPage( dupid: String,
     val t = s"""${top.name} (Team ${tbteam})\n${playerT.trim}"""
     val b = s"""${scorekeeper.name} (Team ${tbteam})\n${playerB.trim}"""
 
-    val cells = getElemsByXPath("""//div/table[2]/tbody/tr/td/span""").map(e => e.text)
+    val cells = getElemsByXPath(HomePage.divBridgeAppPrefix+"""//div/table[2]/tbody/tr/td/span""").map(e => e.text)
     cells.size mustBe 4
 
     if (mustswap) {
@@ -181,7 +182,7 @@ class TableSelectNamesPage( dupid: String,
       if (scorekeeper == North || scorekeeper == East) clickSwapLeft
       else clickSwapRight
       eventually {
-        val cells = getElemsByXPath("""//div/table[2]/tbody/tr/td/span""").map(e => e.text)
+        val cells = getElemsByXPath(HomePage.divBridgeAppPrefix+"""//div/table[2]/tbody/tr/td/span""").map(e => e.text)
         cells.size mustBe 4
         cells mustBe List(t,s"""${l}\nSwap ${Strings.arrowRightLeft}""",s"""${r}\nSwap ${Strings.arrowLeftRight}""",b)
       }

--- a/server/src/test/scala/com/example/test/pages/rubber/ListPage.scala
+++ b/server/src/test/scala/com/example/test/pages/rubber/ListPage.scala
@@ -78,11 +78,11 @@ class ListPage( importId: Option[String] = None )( implicit val webDriver: WebDr
   }
 
   def getMatchButtons()(implicit pos: Position) = {
-    getElemsByXPath("""//div/table/tbody/tr/td[1]/button""").map(e => e.text)
+    getElemsByXPath(HomePage.divBridgeAppPrefix+"""//div/table/tbody/tr/td[1]/button""").map(e => e.text)
   }
 
   def getImportButtons()(implicit pos: Position) = {
-    getElemsByXPath("""//div/table/tbody/tr/td[2]/button""").flatMap(e => e.id.toList)
+    getElemsByXPath(HomePage.divBridgeAppPrefix+"""//div/table/tbody/tr/td[2]/button""").flatMap(e => e.id.toList)
   }
 
   def checkMatchButton( id: String )(implicit pos: Position) = {

--- a/server/src/test/scala/com/example/test/selenium/Chicago5FairTest.scala
+++ b/server/src/test/scala/com/example/test/selenium/Chicago5FairTest.scala
@@ -27,6 +27,7 @@ import com.example.test.util.MonitorTCP
 import com.example.backend.BridgeServiceFileStoreConverters
 import com.example.backend.MatchChicagoCacheStoreSupport
 import com.example.test.pages.PageBrowser
+import com.example.test.pages.bridge.HomePage
 
 /**
  * @author werewolf
@@ -444,7 +445,7 @@ class Chicago5FairTest extends FlatSpec
       val rows = eventually {
         pageTitle mustBe ("The Bridge Score Keeper")
 
-        val rows = findElements(By.xpath("//table[1]/tbody/tr[2]"))
+        val rows = findElements(By.xpath(HomePage.divBridgeAppPrefix+"//table[1]/tbody/tr[1]"))
         rows.size() mustBe 1
         rows
       }
@@ -461,7 +462,7 @@ class Chicago5FairTest extends FlatSpec
       val rows = eventually {
         pageTitle mustBe ("The Bridge Score Keeper")
 
-        val rows = findElements(By.xpath("//table[1]/tbody/tr[1]"))
+        val rows = findElements(By.xpath(HomePage.divBridgeAppPrefix+"//table[1]/tbody/tr[1]"))
         rows.size() mustBe 1
         rows
       }

--- a/server/src/test/scala/com/example/test/selenium/Chicago5SimpleTest.scala
+++ b/server/src/test/scala/com/example/test/selenium/Chicago5SimpleTest.scala
@@ -25,6 +25,7 @@ import com.example.test.util.HttpUtils.ResponseFromHttp
 import com.example.test.util.HttpUtils
 import com.example.backend.BridgeServiceFileStoreConverters
 import com.example.backend.MatchChicagoCacheStoreSupport
+import com.example.test.pages.bridge.HomePage
 
 /**
  * @author werewolf
@@ -360,7 +361,7 @@ class Chicago5SimpleTest extends FlatSpec
       val rows = eventually {
         pageTitle mustBe ("The Bridge Score Keeper")
 
-        val rows = findElements(By.xpath("//table[1]/tbody/tr[2]"))
+        val rows = findElements(By.xpath(HomePage.divBridgeAppPrefix+"//table[1]/tbody/tr[1]"))
         rows.size() mustBe 1
         rows
       }
@@ -377,7 +378,7 @@ class Chicago5SimpleTest extends FlatSpec
       val rows = eventually {
         pageTitle mustBe ("The Bridge Score Keeper")
 
-        val rows = findElements(By.xpath("//table[1]/tbody/tr[1]"))
+        val rows = findElements(By.xpath(HomePage.divBridgeAppPrefix+"//table[1]/tbody/tr[1]"))
         rows.size() mustBe 1
         rows
       }

--- a/server/src/test/scala/com/example/test/selenium/Chicago5Test.scala
+++ b/server/src/test/scala/com/example/test/selenium/Chicago5Test.scala
@@ -22,6 +22,7 @@ import scala.io.Codec
 import com.example.test.util.MonitorTCP
 import com.example.backend.BridgeServiceFileStoreConverters
 import com.example.backend.MatchChicagoCacheStoreSupport
+import com.example.test.pages.bridge.HomePage
 
 /**
  * @author werewolf
@@ -368,7 +369,7 @@ class Chicago5Test extends FlatSpec
       val rows = eventually {
         pageTitle mustBe ("The Bridge Score Keeper")
 
-        val rows = findElements(By.xpath("//table[1]/tbody/tr[2]"))
+        val rows = findElements(By.xpath(HomePage.divBridgeAppPrefix+"//table[1]/tbody/tr[1]"))
         rows.size() mustBe 1
         rows
       }
@@ -385,7 +386,7 @@ class Chicago5Test extends FlatSpec
       val rows = eventually {
         pageTitle mustBe ("The Bridge Score Keeper")
 
-        val rows = findElements(By.xpath("//table[1]/tbody/tr[1]"))
+        val rows = findElements(By.xpath(HomePage.divBridgeAppPrefix+"//table[1]/tbody/tr[1]"))
         rows.size() mustBe 1
         rows
       }

--- a/server/src/test/scala/com/example/test/selenium/ChicagoTest.scala
+++ b/server/src/test/scala/com/example/test/selenium/ChicagoTest.scala
@@ -25,6 +25,7 @@ import com.example.backend.BridgeServiceFileStoreConverters
 import com.example.backend.MatchChicagoCacheStoreSupport
 import com.example.test.pages.PageBrowser
 import com.example.test.TestStartLogging
+import com.example.test.pages.bridge.HomePage
 
 /**
  * @author werewolf
@@ -411,7 +412,7 @@ class ChicagoTest extends FlatSpec
       val rows = eventually {
         pageTitle mustBe ("The Bridge Score Keeper")
 
-        val rows = findElements(By.xpath("//table[1]/tbody/tr[2]"))
+        val rows = findElements(By.xpath(HomePage.divBridgeAppPrefix+"//table[1]/tbody/tr[1]"))
         rows.size() mustBe 1
         rows
       }
@@ -427,7 +428,7 @@ class ChicagoTest extends FlatSpec
       val rows = eventually {
         pageTitle mustBe ("The Bridge Score Keeper")
 
-        val rows = findElements(By.xpath("//table[1]/tbody/tr[1]"))
+        val rows = findElements(By.xpath(HomePage.divBridgeAppPrefix+"//table[1]/tbody/tr[1]"))
         rows.size() mustBe 1
         rows
       }
@@ -559,7 +560,7 @@ class ChicagoTest extends FlatSpec
 
     eventually { find( id("popup") ).isDisplayed mustBe false }
 
-    val buttons = eventually { findAll( xpath( "//table/tbody/tr[2]/td/button" ) ) }
+    val buttons = eventually { findAll( xpath( HomePage.divBridgeAppPrefix+"//table/tbody/tr[1]/td/button" ) ) }
     buttons.size mustBe 2
     val buttontext = buttons(0).text
     buttons(1).click
@@ -570,7 +571,7 @@ class ChicagoTest extends FlatSpec
 
     eventually { find( id("popup") ).isDisplayed mustBe false }
 
-    val buttons2 = eventually { findAll( xpath( "//table/tbody/tr[2]/td/button" ) ) }
+    val buttons2 = eventually { findAll( xpath( HomePage.divBridgeAppPrefix+"//table/tbody/tr[1]/td/button" ) ) }
     buttons2.size mustBe 2
     buttons2(1).click
 
@@ -580,7 +581,7 @@ class ChicagoTest extends FlatSpec
 
     eventually { find( id("popup") ).isDisplayed mustBe false }
 
-    val buttons3 = eventually { findAll( xpath( "//table/tbody/tr[2]/td/button" ) ) }
+    val buttons3 = eventually { findAll( xpath( HomePage.divBridgeAppPrefix+"//table/tbody/tr[1]/td/button" ) ) }
     val button3text = buttons3(0).text
 
     buttontext must not be button3text

--- a/server/src/test/scala/com/example/test/selenium/Duplicate5TestPages.scala
+++ b/server/src/test/scala/com/example/test/selenium/Duplicate5TestPages.scala
@@ -446,18 +446,26 @@ class Duplicate5TestPages extends FlatSpec with MustMatchers with BeforeAndAfter
   it should "create a new duplicate match" in {
     import SessionDirector._
 
-    val curPage = NewDuplicatePage.current
-
-    val boards = MovementsPage.getBoardsFromMovement(movement)
-
-    testlog.info(s"Boards are $boards")
-
-    dupid = curPage.click(boardset, movement).validate(boards).dupid
-    dupid mustBe 'defined
-
-    testlog.info(s"Duplicate id is ${dupid.get}")
-
-    allHands.boardsets mustBe 'defined
+    try {
+    
+      val curPage = NewDuplicatePage.current
+  
+      val boards = MovementsPage.getBoardsFromMovement(movement)
+  
+      testlog.info(s"Boards are $boards")
+  
+      dupid = curPage.click(boardset, movement).validate(boards).dupid
+      dupid mustBe 'defined
+  
+      testlog.info(s"Duplicate id is ${dupid.get}")
+  
+      allHands.boardsets mustBe 'defined
+    } catch {
+      case x: Exception =>
+        testlog.severe("Error creating new duplicate match", x)
+        
+        throw x
+    }
   }
 
   var rounds: List[Int] = Nil

--- a/server/src/test/scala/com/example/test/selenium/RubberTest.scala
+++ b/server/src/test/scala/com/example/test/selenium/RubberTest.scala
@@ -43,10 +43,10 @@ import scala.reflect.io.File
 /**
  * @author werewolf
  */
-class RubberTest extends FlatSpec 
-    with MustMatchers 
-    with BeforeAndAfterAll 
-    with EventuallyUtils 
+class RubberTest extends FlatSpec
+    with MustMatchers
+    with BeforeAndAfterAll
+    with EventuallyUtils
     with SeleniumUtils
     with CancelAfterFailure
 {
@@ -621,7 +621,7 @@ class RubberTest extends FlatSpec
 
     eventually { find( id("popup") ).isDisplayed mustBe false }
 
-    val buttons = eventually { findAll( xpath( "//table/tbody/tr[2]/td/button" ) ) }
+    val buttons = eventually { findAll( xpath( HomePage.divBridgeAppPrefix+"//table/tbody/tr[2]/td/button" ) ) }
     buttons.size mustBe 2
     val buttontext = buttons(0).text
     buttons(1).click
@@ -632,7 +632,7 @@ class RubberTest extends FlatSpec
 
     eventually { find( id("popup") ).isDisplayed mustBe false }
 
-    val buttons2 = eventually { findAll( xpath( "//table/tbody/tr[2]/td/button" ) ) }
+    val buttons2 = eventually { findAll( xpath( HomePage.divBridgeAppPrefix+"//table/tbody/tr[2]/td/button" ) ) }
     buttons2.size mustBe 2
     buttons2(1).click
 
@@ -642,7 +642,7 @@ class RubberTest extends FlatSpec
 
     eventually { find( id("popup") ).isDisplayed mustBe false }
 
-    val buttons3 = eventually { findAll( xpath( "//table/tbody/tr[2]/td/button" ) ) }
+    val buttons3 = eventually { findAll( xpath( HomePage.divBridgeAppPrefix+"//table/tbody/tr[2]/td/button" ) ) }
     val button3text = buttons3(0).text
 
     buttontext must not be button3text

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-git.baseVersion := "1.3.10"
+git.baseVersion := "1.3.11-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-git.baseVersion := "1.3.10-SNAPSHOT"
+git.baseVersion := "1.3.10"


### PR DESCRIPTION
shrink scoreboard page on iPad based on how wide scoreboard is.  This allows the scoreboard to be displayed without scrolling.