### PR TITLE
hand layout should not overflow 1024x768 iPad

### DIFF
--- a/client/src/main/scala/com/example/pages/hand/HandStyles.scala
+++ b/client/src/main/scala/com/example/pages/hand/HandStyles.scala
@@ -75,5 +75,10 @@ class HandStyles {
 
   val titleDeclarerDup = cls("titleDeclarerDup")
   val contractAndResult = cls("contractAndResult")
+
+  val playDuplicate = cls("playDuplicate")
+  val playChicago = cls("playChicago")
+  val playRubber = cls("playRubber")
+
 }
 

--- a/client/src/main/scala/com/example/pages/hand/HandStyles.scala
+++ b/client/src/main/scala/com/example/pages/hand/HandStyles.scala
@@ -74,5 +74,6 @@ class HandStyles {
   val sectionScore = cls("handSectionScore")
 
   val titleDeclarerDup = cls("titleDeclarerDup")
+  val contractAndResult = cls("contractAndResult")
 }
 

--- a/client/src/main/scala/com/example/pages/hand/PageHand.scala
+++ b/client/src/main/scala/com/example/pages/hand/PageHand.scala
@@ -425,35 +425,38 @@ object PageHandInternal {
                       state.declarer,
                       curHonors,
                       curHonorsP,
-                      contract.north,
-                      contract.south,
-                      contract.east,
-                      contract.west,
+//                      contract.north,
+//                      contract.south,
+//                      contract.east,
+//                      contract.west,
                       setMadeOrDown,
                       setTricks,
                       cbHonors,
                       cbHonorsP,
-                      nextInput
+                      nextInput,
+                      contract
                      )
       }
 
-      def sectionContract = SectionContract(state.contractTricks,
-                                            state.contractSuit,
-                                            state.contractDoubled,
-                                            props.allowPassedOut,
-                                            setContractTricks,
-                                            setContractSuit,
-                                            setContractDoubled,
-                                            nextInput
-                                           )
+      def sectionContract(showContractHeader: Boolean ) =
+        SectionContract(state.contractTricks,
+                        state.contractSuit,
+                        state.contractDoubled,
+                        props.allowPassedOut,
+                        setContractTricks,
+                        setContractSuit,
+                        setContractDoubled,
+                        nextInput,
+                        showContractHeader
+                       )
 
       <.div( handStyles.pageHand,
         <.div(
 //          props.teamNS.map( team => TagMod() ).getOrElse( <.span( ^.id:="VerifySectionHeader","Bridge Scorer:") ),
           if (ComponentInputStyleButton.inputMethod == InputMethod.Original) {
-            Seq( sectionHeader, sectionContract ).toTagMod
+            Seq( sectionHeader, sectionContract(true) ).toTagMod
           } else {
-            Seq( sectionContract, sectionHeader ).toTagMod
+            Seq( sectionContract(true), sectionHeader ).toTagMod
           },
           sectionResults,
           SectionScore(contract,nextInput),

--- a/client/src/main/scala/com/example/pages/hand/PageHand.scala
+++ b/client/src/main/scala/com/example/pages/hand/PageHand.scala
@@ -451,6 +451,12 @@ object PageHandInternal {
                        )
 
       <.div( handStyles.pageHand,
+        contract.scoringSystem match {
+        case _ : Duplicate => handStyles.playDuplicate
+        case _ : Chicago => handStyles.playChicago
+        case _ : Rubber => handStyles.playRubber
+        case _ => TagMod()
+        },
         <.div(
 //          props.teamNS.map( team => TagMod() ).getOrElse( <.span( ^.id:="VerifySectionHeader","Bridge Scorer:") ),
           if (ComponentInputStyleButton.inputMethod == InputMethod.Original) {

--- a/client/src/main/scala/com/example/pages/hand/SectionContract.scala
+++ b/client/src/main/scala/com/example/pages/hand/SectionContract.scala
@@ -7,6 +7,7 @@ import com.example.data.bridge.ContractTricks
 import com.example.data.bridge._
 import com.example.pages.hand.PageHandInternal.PageHandNextInput
 import com.example.pages.hand.ComponentInputStyleButton.InputMethod
+import com.example.react.Utils._
 
 /**
  * A skeleton component.
@@ -28,7 +29,9 @@ object SectionContract {
                     callbackTricks: ViewContractTricks.CallbackTricks,
                     callbackSuit: ViewContractSuit.CallbackSuit,
                     callbackDoubled: ViewContractDoubled.CallbackDoubled,
-                    nextInput: PageHandNextInput.Value ) {
+                    nextInput: PageHandNextInput.Value,
+                    showContractHeader: Boolean
+  ) {
     def missingRequired: Boolean = {
       currentTricks match {
         case Some(tricks) =>
@@ -46,13 +49,15 @@ object SectionContract {
              callbackTricks: ViewContractTricks.CallbackTricks,
              callbackSuit: ViewContractSuit.CallbackSuit,
              callbackDoubled: ViewContractDoubled.CallbackDoubled,
-             nextInput: PageHandNextInput.Value) =
-    component(Props(currentTricks,currentSuit,currentDoubled,allowPassedOut,callbackTricks,callbackSuit,callbackDoubled,nextInput))
+             nextInput: PageHandNextInput.Value,
+             showContractHeader: Boolean
+  ) =
+    component(Props(currentTricks,currentSuit,currentDoubled,allowPassedOut,callbackTricks,callbackSuit,callbackDoubled,nextInput,showContractHeader))
 
-  private val header = ScalaComponent.builder[Unit]("SectionHeader")
-                 .render( _ =>
+  private val header = ScalaComponent.builder[Props]("SectionHeader")
+                 .render_P( props =>
                    <.div(
-                     <.span( "Contract:")
+                     props.showContractHeader ?= <.span( "Contract:")
                    )
                  ).build
 
@@ -68,7 +73,7 @@ object SectionContract {
                                 }
                                 <.div(
                                     handStyles.sectionContract,
-                                    header(),
+                                    header(props),
                                     ViewContractTricks(props.allowPassedOut,props.currentTricks,props.callbackTricks, props.nextInput,show( InputContractTricks, true)),
                                     ViewContractSuit(props.currentSuit,props.currentTricks,props.callbackSuit, props.nextInput,show( InputContractSuit)),
                                     ViewContractDoubled(props.currentDoubled,props.callbackDoubled, props.nextInput,show( InputContractDoubled))

--- a/client/src/main/scala/com/example/pages/hand/SectionResult.scala
+++ b/client/src/main/scala/com/example/pages/hand/SectionResult.scala
@@ -119,11 +119,6 @@ object SectionResult {
 
                                     props.contract.scorer match {
                                       case Some(Right(score)) /* Duplicate */ =>
-                                        val c = props.contract
-                                        val ts = c.scoringSystem match {
-                                          case Chicago => score.totalScoreNoPos(c.north,c.south,c.east,c.west)
-                                          case _ => score.totalScore(c.north,c.south,c.east,c.west)
-                                        }
                                         <.div( score.contractAndResultAsString, handStyles.contractAndResult )
 
                                       case _ => TagMod()

--- a/client/src/main/scala/com/example/pages/hand/SectionResult.scala
+++ b/client/src/main/scala/com/example/pages/hand/SectionResult.scala
@@ -30,15 +30,17 @@ object SectionResult {
                     declarer: Option[PlayerPosition],
                     currentHonors: Option[Int],
                     currentHonorsPlayer: Option[PlayerPosition],
-                    north: String,
-                    south: String,
-                    east: String,
-                    west: String,
+//                    north: String,
+//                    south: String,
+//                    east: String,
+//                    west: String,
                     callbackMadeOrDown: ViewMadeOrDown.CallbackMade,
                     callbackTricks: ViewTricks.CallbackTricks,
                     callbackHonors: Option[ViewHonors.CallbackHonors],
                     callbackHonorsPlayer: Option[ViewHonors.CallbackHonorsPlayer],
-                    nextInput: PageHandNextInput.Value ) {
+                    nextInput: PageHandNextInput.Value,
+                    contract: Contract
+  ) {
     def missingRequired = {
       contractTricks match {
         case Some(ct) =>
@@ -58,21 +60,23 @@ object SectionResult {
              declarer: Option[PlayerPosition],
              currentHonors: Option[Int],
              currentHonorsPlayer: Option[PlayerPosition],
-             north: String,
-             south: String,
-             east: String,
-             west: String,
+//             north: String,
+//             south: String,
+//             east: String,
+//             west: String,
              callbackMadeOrDown: ViewMadeOrDown.CallbackMade,
              callbackTricks: ViewTricks.CallbackTricks,
              callbackHonors: Option[ViewHonors.CallbackHonors],
              callbackHonorsPlayer: Option[ViewHonors.CallbackHonorsPlayer],
-             nextInput: PageHandNextInput.Value ) =
+             nextInput: PageHandNextInput.Value,
+             contract: Contract
+           ) =
     component(Props(madeOrDown,tricks,contractTricks,contractSuit,contractDoubled,declarer,
                     currentHonors, currentHonorsPlayer,
-                    north,south,east,west,
+//                    north,south,east,west,
                     callbackMadeOrDown,callbackTricks,
                     callbackHonors, callbackHonorsPlayer,
-                    nextInput))
+                    nextInput, contract))
 
   def header = ScalaComponent.builder[Unit]("SectionHeader")
                  .render( _ =>
@@ -98,7 +102,7 @@ object SectionResult {
                                     ViewHonors(props.currentHonors, props.currentHonorsPlayer,
                                                props.contractTricks,
                                                props.contractSuit,
-                                               props.north, props.south, props.east, props.west,
+                                               props.contract.north, props.contract.south, props.contract.east, props.contract.west,
                                                props.callbackHonors.get,
                                                props.callbackHonorsPlayer.get,
                                                props.nextInput)
@@ -110,7 +114,21 @@ object SectionResult {
                                       showButtons ?= ViewMadeOrDown(props.madeOrDown,props.callbackMadeOrDown, props.nextInput, show(InputResultMadeOrDown)),
                                       showButtons ?= ViewTricks(props.tricks,props.contractTricks,props.madeOrDown,props.callbackTricks, props.nextInput, show(InputResultTricks))
                                     )
-                                  )
+                                  ),
+                                  props.callbackHonors.isEmpty ?= {
+
+                                    props.contract.scorer match {
+                                      case Some(Right(score)) /* Duplicate */ =>
+                                        val c = props.contract
+                                        val ts = c.scoringSystem match {
+                                          case Chicago => score.totalScoreNoPos(c.north,c.south,c.east,c.west)
+                                          case _ => score.totalScore(c.north,c.south,c.east,c.west)
+                                        }
+                                        <.div( score.contractAndResultAsString, handStyles.contractAndResult )
+
+                                      case _ => TagMod()
+                                    }
+                                }
                                 )
                             })
                             .build

--- a/client/src/main/scala/com/example/pages/hand/SectionScore.scala
+++ b/client/src/main/scala/com/example/pages/hand/SectionScore.scala
@@ -40,7 +40,7 @@ object SectionScore {
                                         val c = props.contract
                                         TagMod(
                                           <.div("Score: "+score.totalScore(c.north,c.south,c.east,c.west)),
-                                          <.div(score.contractAndResultAsString ),
+                                          <.div(score.contractAndResultAsString, handStyles.contractAndResult ),
                                           <.div(score.explain())
                                         )
                                       case Some(Right(score)) /* Duplicate */ =>
@@ -51,7 +51,7 @@ object SectionScore {
                                         }
                                         TagMod(
                                           <.div("Score: "+ts ),
-                                          <.div(score.contractAndResultAsString ),
+//                                          <.div(score.contractAndResultAsString, handStyles.contractAndResult ),
                                           <.div(score.explain() )
                                         )
                                       case None =>
@@ -72,7 +72,6 @@ object SectionScore {
                                         }
                                         TagMod(
                                           <.div(handStyles.required, "Missing required information" ),
-                                          <.div(),
                                           <.div(handStyles.required, msg )
                                         )
                                     }

--- a/client/src/main/scala/com/example/pages/hand/SectionScore.scala
+++ b/client/src/main/scala/com/example/pages/hand/SectionScore.scala
@@ -46,7 +46,7 @@ object SectionScore {
                                       case Some(Right(score)) /* Duplicate */ =>
                                         val c = props.contract
                                         val ts = c.scoringSystem match {
-                                          case Chicago => score.totalScoreNoPos(c.north,c.south,c.east,c.west)
+                                          case _ : Chicago => score.totalScoreNoPos(c.north,c.south,c.east,c.west)
                                           case _ => score.totalScore(c.north,c.south,c.east,c.west)
                                         }
                                         TagMod(

--- a/server/src/main/public/css/bridge.css
+++ b/server/src/main/public/css/bridge.css
@@ -681,4 +681,5 @@ body > div > div > div {
   display: flex;
   flex-direction: row;
   overflow: hidden;
+  text-shadow: 3px 3px 3px #f00;
 }

--- a/server/src/main/public/css/hand.css
+++ b/server/src/main/public/css/hand.css
@@ -182,8 +182,8 @@
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
-  justify-content: flex-start;
-  align-items: flex-start;
+  justify-content: space-between;
+  align-items: flex-end;
   width: 100%;
   min-height: 135px;
 }
@@ -278,7 +278,13 @@
   padding: 0 10px 0 10px;
 }
 
-.handSectionScore > div:nth-child(2) {
+.handSectionScore > div:first-child {
   background: cyan;
 }
 
+.contractAndResult {
+  background: cyan;
+}
+.handSectionResult .contractAndResult {
+  padding-right: 10px;
+}

--- a/server/src/main/public/css/hand.css
+++ b/server/src/main/public/css/hand.css
@@ -278,12 +278,16 @@
   padding: 0 10px 0 10px;
 }
 
-.handSectionScore > div:first-child {
-  background: cyan;
+.playDuplicate .handSectionScore > div:first-child {
+  background-color: cyan;
+}
+
+.playChicago .handSectionScore > div:first-child {
+  background-color: cyan;
 }
 
 .contractAndResult {
-  background: cyan;
+  background-color: cyan;
 }
 .handSectionResult .contractAndResult {
   padding-right: 10px;

--- a/server/src/main/public/demo-fastopt.html
+++ b/server/src/main/public/demo-fastopt.html
@@ -34,8 +34,13 @@
                   font-size: x-large;
                   height: 64px;
                  " >
-        <h6 style="font-size: 1.25rem; font-family: Arial, sans-serif; font-weight: 500; line-height: 1.6; letter-spacing: 0.0075em;
-            " >Bridge ScoreKeeper</h6>
+        <h6 style="font-size: 1.25rem; 
+                   font-family: Arial, sans-serif; 
+                   font-weight: 500; 
+                   line-height: 1.6; 
+                   letter-spacing: 0.0075em;
+                   text-shadow: 1px 2px 3px #f00;
+            " >Demo Bridge ScoreKeeper</h6>
         <span style="padding-left: 30px; font-size: 2.5rem">
             <span class="headerSuitSize" style="color: black;"> &spades;</span>
             <span class="headerSuitSize" style="color: red;"> &hearts;</span>
@@ -43,7 +48,7 @@
             <span class="headerSuitSize" style="color: black;"> &clubs;</span>
         </span>
       </div>
-      <h1>Loading ...</h1>
+      <h1 style="padding-left: 8px">Loading ...</h1>
     </div>
     <script type="text/javascript">
         var demo = true

--- a/server/src/main/public/demo.html
+++ b/server/src/main/public/demo.html
@@ -34,8 +34,13 @@
                   font-size: x-large;
                   height: 64px;
                  " >
-        <h6 style="font-size: 1.25rem; font-family: Arial, sans-serif; font-weight: 500; line-height: 1.6; letter-spacing: 0.0075em;
-            " >Bridge ScoreKeeper</h6>
+        <h6 style="font-size: 1.25rem; 
+                   font-family: Arial, sans-serif; 
+                   font-weight: 500; 
+                   line-height: 1.6; 
+                   letter-spacing: 0.0075em;
+                   text-shadow: 1px 2px 3px #f00;
+            " >Demo Bridge ScoreKeeper</h6>
         <span style="padding-left: 30px; font-size: 2.5rem">
             <span class="headerSuitSize" style="color: black;"> &spades;</span>
             <span class="headerSuitSize" style="color: red;"> &hearts;</span>
@@ -43,7 +48,7 @@
             <span class="headerSuitSize" style="color: black;"> &clubs;</span>
         </span>
       </div>
-      <h1>Loading ...</h1>
+      <h1 style="padding-left: 8px">Loading ...</h1>
     </div>
     <script type="text/javascript">
         var demo = true

--- a/server/src/main/public/index-fastopt.html
+++ b/server/src/main/public/index-fastopt.html
@@ -32,7 +32,12 @@
                   font-size: x-large;
                   height: 50px;
                  " >
-        <h6 style="font-size: 1.25rem; font-family: Arial, sans-serif; font-weight: 500; line-height: 1.6; letter-spacing: 0.0075em;
+        <h6 style="font-size: 1.25rem; 
+                   font-family: Arial, sans-serif; 
+                   font-weight: 500; 
+                   line-height: 1.6; 
+                   letter-spacing: 0.0075em;
+                   text-shadow: 1px 2px 3px #f00;
             " >Bridge ScoreKeeper</h6>
         <span style="padding-left: 30px; font-size: 2.5rem">
             <span class="headerSuitSize" style="color: black;"> &spades;</span>
@@ -41,7 +46,7 @@
             <span class="headerSuitSize" style="color: black;"> &clubs;</span>
         </span>
       </div>
-      <h1>Loading ...</h1>
+      <h1 style="padding-left: 8px">Loading ...</h1>
     </div>
     <!-- Include Scala.js compiled code -->
     <script type="text/javascript" src="bridgescorer-client-fastopt-library.js"></script>

--- a/server/src/main/public/index-jsconsole.html
+++ b/server/src/main/public/index-jsconsole.html
@@ -33,7 +33,12 @@
                   font-size: x-large;
                   height: 50px;
                  " >
-        <h6 style="font-size: 1.25rem; font-family: Arial, sans-serif; font-weight: 500; line-height: 1.6; letter-spacing: 0.0075em;
+        <h6 style="font-size: 1.25rem; 
+                   font-family: Arial, sans-serif; 
+                   font-weight: 500; 
+                   line-height: 1.6; 
+                   letter-spacing: 0.0075em;
+                   text-shadow: 1px 2px 3px #f00;
             " >Bridge ScoreKeeper</h6>
         <span style="padding-left: 30px; font-size: 2.5rem">
             <span class="headerSuitSize" style="color: black;"> &spades;</span>
@@ -42,7 +47,7 @@
             <span class="headerSuitSize" style="color: black;"> &clubs;</span>
         </span>
       </div>
-      <h1>Loading ...</h1>
+      <h1 style="padding-left: 8px">Loading ...</h1>
     </div>
     <!-- Include Scala.js compiled code -->
     <script type="text/javascript" src="bridgescorer-client-fastopt-library.js"></script>

--- a/server/src/main/public/index.html
+++ b/server/src/main/public/index.html
@@ -34,7 +34,12 @@
                   font-size: x-large;
                   height: 50px;
                  " >
-        <h6 style="font-size: 1.25rem; font-family: Arial, sans-serif; font-weight: 500; line-height: 1.6; letter-spacing: 0.0075em;
+        <h6 style="font-size: 1.25rem; 
+                   font-family: Arial, sans-serif; 
+                   font-weight: 500; 
+                   line-height: 1.6; 
+                   letter-spacing: 0.0075em;
+                   text-shadow: 1px 2px 3px #f00;
             " >Bridge ScoreKeeper</h6>
         <span style="padding-left: 30px; font-size: 2.5rem">
             <span class="headerSuitSize" style="color: black;"> &spades;</span>
@@ -43,7 +48,7 @@
             <span class="headerSuitSize" style="color: black;"> &clubs;</span>
         </span>
       </div>
-      <h1>Loading ...</h1>
+      <h1 style="padding-left: 8px">Loading ...</h1>
     </div>
     <!-- Include Scala.js compiled code -->
     <script type="text/javascript" src="bridgescorer-client-opt-library.js.gz"></script>

--- a/server/src/main/public/indexNoScale.html
+++ b/server/src/main/public/indexNoScale.html
@@ -51,7 +51,12 @@
                   font-size: x-large;
                   height: 50px;
                  " >
-        <h6 style="font-size: 1.25rem; font-family: Arial, sans-serif; font-weight: 500; line-height: 1.6; letter-spacing: 0.0075em;
+        <h6 style="font-size: 1.25rem; 
+                   font-family: Arial, sans-serif; 
+                   font-weight: 500; 
+                   line-height: 1.6; 
+                   letter-spacing: 0.0075em;
+                   text-shadow: 1px 2px 3px #f00;
             " >Bridge ScoreKeeper</h6>
         <span style="padding-left: 30px; font-size: 2.5rem">
             <span class="headerSuitSize" style="color: black;"> &spades;</span>
@@ -60,7 +65,7 @@
             <span class="headerSuitSize" style="color: black;"> &clubs;</span>
         </span>
       </div>
-      <h1>Loading ...</h1>
+      <h1 style="padding-left: 8px">Loading ...</h1>
     </div>
     <!-- Include Scala.js compiled code -->
     <script type="text/javascript" src="bridgescorer-client-opt-library.js.gz"></script>

--- a/server/src/test/scala/com/example/test/pages/bridge/BaseHandPage.scala
+++ b/server/src/test/scala/com/example/test/pages/bridge/BaseHandPage.scala
@@ -374,6 +374,12 @@ abstract class BaseHandPage( implicit webDriver: WebDriver, pageCreated: SourceP
     eventually {
       findElemsByXPath( "//div[contains(concat(' ', @class, ' '), ' handSectionScore ')]/div" ) match {
         case List( r1, r2, r3 ) => ( r1.text, r2.text, r3.text )
+        case List( r1, r3 ) =>
+          findElemsByXPath( "//div[contains(concat(' ', @class, ' '), ' contractAndResult ')]" ) match {
+            case List( r2 ) => ( r1.text, r2.text, r3.text )
+            case x => ( r1.text, "", r3.text )
+          }
+
         case x => fail(s"Did not get exactly three elements: $x")
       }
     }


### PR DESCRIPTION
in landscape mode, height is only 643px address bar and tabs take the
extra space

shadow effect on appbar text

cyan color or result contract on hand page.  On duplicate and chicago hand page cyan color of total score.