### PR TITLE
switch to zsh from bash

### DIFF
--- a/server/src/main/resources/collectlogs
+++ b/server/src/main/resources/collectlogs
@@ -9,7 +9,7 @@ Syntax: $0 [-h|--help]
 
 Collects the diagnostic information and saves it in logs.zip.
 Java 8 must be on the path.
-  
+
 HELPMEHELPME
 }
 
@@ -20,14 +20,17 @@ fi
 
 cd $SCRIPTDIR
 
-jarcount=`ls -1f bridgescorer-server-assembly-*.jar bridgescorekeeper-*.jar 2>/dev/null | wc -l`
-if [[ $jarcount -ne "1" ]] ; then 
+# looking for jar files with the following file name patterns:
+#   bridgescorer-server-assembly-*.jar
+#   bridgescorekeeper-*.jar
+jarcount=`ls -1f *.jar 2>/dev/null | wc -l`
+if [[ $jarcount -ne "1" ]] ; then
   echo Did not find one bridgescorer jar file in directory, found $jarcount
-  ls bridgescorer-server-assembly-*.jar bridgescorekeeper-*.jar 2>/dev/null
+  ls *.jar 2>/dev/null
   exit 1
 fi
 
-oldjar=`ls -1f bridgescorer-server-assembly-*.jar bridgescorekeeper-*.jar 2>/dev/null`
+oldjar=`ls -1f *.jar 2>/dev/null`
 
 java -jar $oldjar collectlogs --store ./store --diagnostics ./logs --zip logs.zip
 

--- a/server/src/main/resources/server
+++ b/server/src/main/resources/server
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/zsh
 
 SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
@@ -8,7 +8,7 @@ helpme()
 Syntax: $0 [-h|--help]
 
 Starts the bridge scorer server.  Java 8 must be on the path.
-  
+
 HELPMEHELPME
 }
 
@@ -19,15 +19,17 @@ fi
 
 cd $SCRIPTDIR
 
-jarcount=`ls -1f bridgescorer-server-assembly-*.jar bridgescorekeeper-*.jar 2>/dev/null | wc -l`
-if [[ $jarcount -ne "1" ]] ; then 
+# looking for jar files with the following file name patterns:
+#   bridgescorer-server-assembly-*.jar
+#   bridgescorekeeper-*.jar
+jarcount=`ls -1f *.jar 2>/dev/null | wc -l`
+if [[ $jarcount -ne "1" ]] ; then
   echo Did not find one bridgescorer jar file in directory, found $jarcount
-  ls bridgescorer-server-assembly-*.jar bridgescorekeeper-*.jar 2>/dev/null
+  ls *.jar 2>/dev/null
   exit 1
 fi
 
-oldjar=`ls -1f bridgescorer-server-assembly-*.jar bridgescorekeeper-*.jar 2>/dev/null`
+oldjar=`ls -1f *.jar 2>/dev/null`
 
 mkdir logs 2>/dev/null
 java -jar $oldjar --logfile logs/server.%d.%u.log start --store ./store --port 8080 --browser --diagnostics logs
-

--- a/server/src/main/resources/serverMemory
+++ b/server/src/main/resources/serverMemory
@@ -8,7 +8,7 @@ helpme()
 Syntax: $0 [-h|--help]
 
 Starts the bridge scorer server.  Java 8 must be on the path.
-  
+
 HELPMEHELPME
 }
 
@@ -19,14 +19,17 @@ fi
 
 cd $SCRIPTDIR
 
-jarcount=`ls -1f bridgescorer-server-assembly-*.jar bridgescorekeeper-*.jar 2>/dev/null | wc -l`
-if [[ $jarcount -ne "1" ]] ; then 
+# looking for jar files with the following file name patterns:
+#   bridgescorer-server-assembly-*.jar
+#   bridgescorekeeper-*.jar
+jarcount=`ls -1f *.jar 2>/dev/null | wc -l`
+if [[ $jarcount -ne "1" ]] ; then
   echo Did not find one bridgescorer jar file in directory, found $jarcount
-  ls bridgescorer-server-assembly-*.jar bridgescorekeeper-*.jar 2>/dev/null
+  ls *.jar 2>/dev/null
   exit 1
 fi
 
-oldjar=`ls -1f bridgescorer-server-assembly-*.jar bridgescorekeeper-*.jar 2>/dev/null`
+oldjar=`ls -1f *.jar 2>/dev/null`
 
 mkdir logs 2>/dev/null
 java -jar $oldjar --logfile logs/server.%d.%u.log --memoryfile logs/memory.%%d.csv start --store ./store --port 8080 --browser --diagnostics logs

--- a/server/src/main/resources/update
+++ b/server/src/main/resources/update
@@ -8,7 +8,7 @@ helpme()
 Syntax: $0 [-h|--help]
 
 Starts the bridge scorer server.  Java 8 must be on the path.
-  
+
 HELPMEHELPME
 }
 
@@ -19,14 +19,17 @@ fi
 
 cd $SCRIPTDIR
 
-jarcount=`ls -1f bridgescorer-server-assembly-*.jar bridgescorekeeper-*.jar 2>/dev/null | wc -l`
-if [[ $jarcount -ne "1" ]] ; then 
+# looking for jar files with the following file name patterns:
+#   bridgescorer-server-assembly-*.jar
+#   bridgescorekeeper-*.jar
+jarcount=`ls -1f *.jar 2>/dev/null | wc -l`
+if [[ $jarcount -ne "1" ]] ; then
   echo Did not find one bridgescorer jar file in directory, found $jarcount
-  ls bridgescorer-server-assembly-*.jar bridgescorekeeper-*.jar 2>/dev/null
+  ls *.jar 2>/dev/null
   exit 1
 fi
 
-oldjar=`ls -1f bridgescorer-server-assembly-*.jar bridgescorekeeper-*.jar 2>/dev/null`
+oldjar=`ls -1f *.jar 2>/dev/null`
 
 java -jar $oldjar update
 if [[ $? -ne 0 ]] ; then
@@ -34,15 +37,15 @@ if [[ $? -ne 0 ]] ; then
   exit 1
 fi
 
-jarcount2=`ls -1f bridgescorer-server-assembly-*.jar bridgescorekeeper-*.jar 2>/dev/null | wc -l`
-if [[ $jarcount2 -ne "2" ]] ; then 
+jarcount2=`ls -1f *.jar 2>/dev/null | wc -l`
+if [[ $jarcount2 -ne "2" ]] ; then
   echo jar count is $jarcount2
   echo Should find both old and new bridgescorer jar file in directory, found $jarcount2
-  ls bridgescorer-server-assembly-*.jar bridgescorekeeper-*.jar 2>/dev/null
+  ls *.jar 2>/dev/null
   exit 1
 fi
 
-files=(`ls -f bridgescorer-server-assembly-*.jar bridgescorekeeper-*.jar 2>/dev/null`)
+files=(`ls -1f *.jar 2>/dev/null`)
 
 if [[ "${files[0]}" == "$oldjar" ]] ; then
   newjar=${files[1]}


### PR DESCRIPTION
zsh command line expansion for files is different from bash.

zsh will fail command if a token with a wildcard does not expand to a file.